### PR TITLE
Update supported-platforms.md

### DIFF
--- a/features/supported-platforms.md
+++ b/features/supported-platforms.md
@@ -18,3 +18,25 @@ openHAB is a pure java based platform so it can be run anywhere where java runs.
 openHAB runs at any standard Windows, MacOS X or Linux machine with Java 1.7.
 
 openHAB has been tested and known to run on the following embedded platforms: [Raspberry Pi](http://www.raspberrypi.org/) , [BeagleBone Black](http://www.beaglebone.org/) , [UDOO](http://www.udoo.org/) , [Cubietruck](http://cubieboard.org/) .
+
+
+## Windows x64
+
+The following workaround may be necessary to get Designer running on 64-bit Windows (as reported [here](https://github.com/openhab/openhab/issues/1714)).
+
+    Go to Oracle's website and download the JRE: (eg. jre-8u25-windows-i586.tar.gz)
+    http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html
+    
+    Extract the archive into your folder of the openHAB designer.
+    You should have the content
+    ...
+    jre1.8.0_25 (folder)
+    openHAB-Designer.exe
+    
+    Create a shortcut of openHAB-Designer.exe
+    
+    Edit the shortcut (Properties -> Shotcut -> Target) and add the following
+    -vm jre1.8.0_25\bin\javaw.exe
+    
+    Start openHAB Designer with the shortcut. It should use the "embedded" x86 JRE.
+


### PR DESCRIPTION
Update the documentation to include the workaround for running Designer on 64-bit Windows (see #1714 - Designer support for windows x64).