### PR TITLE
Update GitHub link to go openHAB GitHub main page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,7 +8,7 @@
             <li><a href="{{ site.baseurl }}/downloads.html"{% if pageurl[1] == 'downloads.html' %} class="active"{% endif %}>Downloads</a></li>
             <li><a href="http://docs.openhab.org" target="_blank">Documentation</a></li>
             <li><a href="https://community.openhab.org" target="_blank">Community</a></li>
-            <li><a href="https://github.com/openhab/openhab" target="_blank">Github</a></li>
+            <li><a href="https://github.com/openhab/" target="_blank">Github</a></li>
             <li><a href="http://www.myopenhab.org/" target="_blank">myopenHAB</a></li>
           </ul>
         </nav>


### PR DESCRIPTION
rather than openhab-addons1 page